### PR TITLE
Refine intro pacing and deepen ambient network

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,9 @@
       line-height:var(--lh);
       -webkit-font-smoothing:antialiased;
       text-rendering:optimizeLegibility;
+      transition: background 1.6s ease, color .8s ease;
     }
+    body[data-phase="intro"]{ overflow:hidden; }
     body::before{
       content:"";
       position:fixed;
@@ -66,7 +68,9 @@
       backdrop-filter: blur(6px);
       background: color-mix(in oklab, var(--bg) 85%, transparent);
       border-bottom:1px solid var(--edge);
+      transition: transform .9s ease .35s, opacity .9s ease .35s;
     }
+    body[data-phase="intro"] header{ opacity:0; transform: translateY(-30px); }
     .nav{ display:flex; align-items:center; justify-content:space-between; padding:16px var(--pad); }
     .brand{ font-weight:600; letter-spacing:.02em; }
     .nav a{ opacity:.86; }
@@ -78,7 +82,9 @@
       position:relative; isolation:isolate;
       padding-block: clamp(96px, 20vh, 160px);
       overflow:hidden;
+      transition: transform 1.1s ease .45s, opacity 1.1s ease .45s;
     }
+    body[data-phase="intro"] .hero{ opacity:0; transform: translateY(40px); }
     .hero .center{ position:relative; }
     .hero h1{
       font-size:clamp(2rem, 6vw, 4rem);
@@ -196,10 +202,79 @@
       position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden;
     }
     .skip:focus{ position:fixed; left:16px; top:12px; width:auto; height:auto; padding:8px 12px; background:#000; border:1px solid var(--edge); border-radius:10px; z-index:999; }
+
+    /* ====== Dimensional background canvas ====== */
+    #networkCanvas{
+      position:fixed;
+      inset:0;
+      z-index:-2;
+      pointer-events:none;
+      filter: blur(1px);
+      mix-blend-mode:screen;
+      opacity:0;
+      transition: opacity 1.8s ease;
+    }
+    body[data-phase="intro"] #networkCanvas{ opacity:0; }
+
+    /* ====== Intro overlay ====== */
+    #intro-overlay{
+      position:fixed;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      background: radial-gradient(circle at 50% 40%, rgba(18,22,28,.6), rgba(8,10,14,.92));
+      z-index:20;
+      pointer-events:none;
+      transition: opacity 1s ease;
+    }
+    #intro-overlay::after{
+      content:"";
+      position:absolute;
+      inset:10%;
+      border:1px solid rgba(157,178,191,.08);
+      pointer-events:none;
+      mix-blend-mode:screen;
+    }
+    #intro-overlay h1{
+      font-size: clamp(2.4rem, 8vw, 5.2rem);
+      letter-spacing:.38em;
+      font-weight:500;
+      margin:0;
+      text-transform:uppercase;
+      color: color-mix(in oklab, var(--accent-4) 45%, var(--text));
+      text-shadow:0 0 60px rgba(157,178,191,.15);
+    }
+    body[data-phase="revealed"] #intro-overlay{ opacity:0; pointer-events:none; }
+    body[data-phase="revealed"] main,
+    body[data-phase="revealed"] footer{ opacity:1; }
+    body[data-phase="intro"] main,
+    body[data-phase="intro"] footer{ opacity:0; }
+
+    main, footer{ transition: opacity 1.35s ease .5s; }
+
+    @media (prefers-reduced-motion: reduce){
+      #networkCanvas{ display:none; }
+      #intro-overlay{ transition:none; }
+      header, .hero, main, footer{ transition:none; }
+    }
   </style>
 </head>
-<body>
+<body data-phase="intro">
+  <canvas id="networkCanvas" aria-hidden="true"></canvas>
+  <div id="intro-overlay" role="presentation">
+    <h1>ONONO</h1>
+  </div>
   <a class="skip" href="#content">Skip to content</a>
+  <noscript>
+    <style>
+      body[data-phase="intro"] #intro-overlay{display:none;}
+      body[data-phase="intro"] header{opacity:1; transform:none;}
+      body[data-phase="intro"] .hero{opacity:1; transform:none;}
+      body[data-phase="intro"] main,
+      body[data-phase="intro"] footer{opacity:1;}
+    </style>
+  </noscript>
 
   <!-- ====== Header / Nav ====== -->
   <header>
@@ -339,5 +414,351 @@
       </div>
     </div>
   </footer>
+
+  <script>
+    (function(){
+      const body = document.body;
+      const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (motionQuery.matches) {
+        body.dataset.phase = 'revealed';
+        return;
+      }
+
+      const introStart = performance.now();
+      const INTRO_MIN = 2200;
+      const AUTO_REVEAL = 3200;
+
+      const finishReveal = () => {
+        if (body.dataset.phase !== 'revealed') {
+          body.dataset.phase = 'revealed';
+          document.removeEventListener('scroll', requestReveal);
+        }
+      };
+
+      const requestReveal = () => {
+        if (body.dataset.phase === 'revealed') return;
+        const elapsed = performance.now() - introStart;
+        const wait = Math.max(0, INTRO_MIN - elapsed);
+        if (wait > 0) {
+          setTimeout(finishReveal, wait);
+        } else {
+          finishReveal();
+        }
+        window.removeEventListener('pointerdown', requestReveal);
+        window.removeEventListener('keydown', requestReveal);
+      };
+
+      setTimeout(requestReveal, AUTO_REVEAL);
+      document.addEventListener('scroll', requestReveal, { passive: true, once: true });
+      window.addEventListener('pointerdown', requestReveal, { once: true });
+      window.addEventListener('keydown', requestReveal, { once: true });
+
+      const canvas = document.getElementById('networkCanvas');
+      if (!canvas || !canvas.getContext) return;
+      const ctx = canvas.getContext('2d');
+      const keywords = `time, temporality, event, events, history, causality, narrative, story, sequence, chain of evidence, perspective, multi-perspective, intersubjectivity, subjectivity, viewpoint, voice, discourse, meaning, interpretation, understanding, explanation, knowledge, memory, data, information, computation, process, relation, relationships, connection, link, mapping, structure, pattern, category, abstraction, generalization, metaphor, symbol, language, words, concepts, ontology, nested ontologies, overlapping networks, networks, graph, web, system, dynamics, change, transformation, evolution, emergence, complexity, uncertainty, volatility, openness, context, world, reality, representation, model, surface, essence, appearance, nature, substance, form, difference, similarity, contrast, identity, otherness, boundary, limit, horizon, possibility, potential, hypothesis, assumption, evaluation, testing, critique, reflection, recursion, iteration, self-reference, feedback, loop, correlation, autocorrelation, autoregression, induction, deduction, abduction, analysis, synthesis, statistics, probability, inference, reason, logic, causation, consequence, choice, decision, judgment, agency, action, tool, instrument, construction, recombination, composition, innovation, creativity, imagination, discovery, invention, novelty, intuition, consciousness, awareness, presence, emergence, essence, meaning-making, interpretation, hermeneutics, phenomenology, epistemology, ontology, ethics, responsibility, trust, alignment, cooperation, dialogue, communication, interrelation, interaction, resonance, coherence, continuity, disruption, fragmentation, wholeness, totality, plurality, diversity, unity, paradox, ambiguity, uncertainty, openness, possibility, potentiality, transcendence`.split(',').map(k => k.trim());
+
+      const NODE_COUNT = 82;
+      const rand = (min, max) => Math.random() * (max - min) + min;
+      const state = {
+        nodes: [],
+        mouse: { speed: 0 },
+        pointer: { x: 0.5, y: 0.5, active: false, polarity: 1, radius: 0.16, lastMove: 0 },
+        visibility: 0,
+        targetVisibility: 0
+      };
+
+      const schedule = {
+        start: performance.now() + rand(3000, 7000),
+        nextPulse: Infinity,
+        pulseEnd: -1
+      };
+
+      const schedulePulse = (from) => {
+        schedule.nextPulse = from + rand(3000, 8000);
+        schedule.pulseEnd = schedule.nextPulse + rand(1000, 3000);
+      };
+      schedulePulse(schedule.start);
+
+      function resize() {
+        const ratio = window.devicePixelRatio || 1;
+        canvas.width = window.innerWidth * ratio;
+        canvas.height = window.innerHeight * ratio;
+        ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+      }
+      resize();
+      window.addEventListener('resize', resize);
+
+      function createNode(index) {
+        const now = performance.now();
+        return {
+          x: Math.random(),
+          y: Math.random(),
+          z: Math.random(),
+          vx: rand(-0.00028, 0.00028),
+          vy: rand(-0.00028, 0.00028),
+          drift: rand(0.12, 0.55),
+          phase: rand(0, Math.PI * 2),
+          wobble: rand(0.18, 0.65),
+          word: keywords[Math.floor(Math.random() * keywords.length)],
+          swapAt: now + rand(6000, 20000),
+          randomLink: null,
+          randomLink2: null,
+          randomLinkExpiry: now + rand(4000, 9000),
+          randomLink2Expiry: now + rand(6000, 12000),
+          shimmer: 0,
+          pointerGlow: 0,
+          pointerShade: 0,
+          pulseAt: now + rand(4000, 13000),
+          speedBias: rand(0.65, 1.15),
+          speedPhase: rand(0, Math.PI * 2)
+        };
+      }
+
+      for (let i = 0; i < NODE_COUNT; i++) {
+        state.nodes.push(createNode(i));
+      }
+      for (let i = 0; i < NODE_COUNT; i++) {
+        const node = state.nodes[i];
+        node.randomLink = Math.floor(Math.random() * NODE_COUNT);
+        if (node.randomLink === i) node.randomLink = (node.randomLink + 7) % NODE_COUNT;
+        node.randomLink2 = Math.floor(Math.random() * NODE_COUNT);
+        if (node.randomLink2 === i || node.randomLink2 === node.randomLink) {
+          node.randomLink2 = (node.randomLink2 + 13) % NODE_COUNT;
+        }
+      }
+
+      let lastTime = performance.now();
+      let noiseSeed = rand(0, 1000);
+      const maxSpeed = 1000;
+
+      function update(now) {
+        const dt = Math.min((now - lastTime) / 16, 4);
+        lastTime = now;
+
+        const ratio = window.devicePixelRatio || 1;
+        const width = canvas.width / ratio;
+        const height = canvas.height / ratio;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        if (now >= schedule.start) {
+          if (schedule.nextPulse === Infinity) {
+            schedulePulse(now);
+          }
+          if (now >= schedule.nextPulse && now <= schedule.pulseEnd) {
+            state.targetVisibility = 0.55;
+          } else {
+            state.targetVisibility = 0.04;
+            if (now > schedule.pulseEnd) {
+              schedulePulse(now);
+            }
+          }
+        } else {
+          state.targetVisibility = 0;
+        }
+
+        state.visibility += (state.targetVisibility - state.visibility) * 0.04;
+        const visibleOpacity = now >= schedule.start ? 0.02 + state.visibility * 0.85 : 0;
+        canvas.style.opacity = visibleOpacity.toFixed(3);
+
+        const motionFactor = 0.55 + Math.min(state.mouse.speed / maxSpeed, 0.9);
+        const pointer = state.pointer;
+
+        ctx.save();
+        ctx.translate(0.5, 0.5);
+
+        if (pointer.active && now - pointer.lastMove > 480) {
+          pointer.active = false;
+        }
+
+        for (let i = 0; i < state.nodes.length; i++) {
+          const node = state.nodes[i];
+          node.phase += 0.0019 * dt * node.drift * (0.7 + motionFactor * 0.35);
+          const variability = node.speedBias + Math.sin(now / 2000 + node.speedPhase) * 0.25;
+          const speed = (0.32 + motionFactor * 0.45) * variability;
+          node.x += (node.vx * 0.8 + Math.sin(node.phase + noiseSeed) * 0.00035 * node.wobble) * dt * speed;
+          node.y += (node.vy * 0.8 + Math.cos(node.phase - noiseSeed) * 0.00035 * node.wobble) * dt * speed;
+          node.z += Math.sin(now / 1400 + node.phase * 1.4) * 0.0005 * dt;
+          node.z = Math.min(0.95, Math.max(0.05, node.z));
+
+          if (node.x < -0.12) node.x = 1.12;
+          if (node.x > 1.12) node.x = -0.12;
+          if (node.y < -0.12) node.y = 1.12;
+          if (node.y > 1.12) node.y = -0.12;
+
+          if (now > node.swapAt) {
+            node.word = keywords[Math.floor(Math.random() * keywords.length)];
+            node.swapAt = now + rand(8000, 26000);
+          }
+          if (now > node.randomLinkExpiry) {
+            node.randomLinkExpiry = now + rand(6000, 13000);
+            let idx = Math.floor(Math.random() * NODE_COUNT);
+            if (idx === i) idx = (idx + 9) % NODE_COUNT;
+            node.randomLink = idx;
+          }
+          if (now > node.randomLink2Expiry) {
+            node.randomLink2Expiry = now + rand(8000, 16000);
+            let idx = Math.floor(Math.random() * NODE_COUNT);
+            if (idx === i || idx === node.randomLink) idx = (idx + 11) % NODE_COUNT;
+            node.randomLink2 = idx;
+          }
+
+          if (now > node.pulseAt) {
+            node.shimmer = 1.2;
+            node.pulseAt = now + rand(6000, 14000);
+          }
+          node.shimmer *= 0.94;
+          node.pointerGlow *= 0.88;
+          node.pointerShade *= 0.88;
+
+          if (pointer.active) {
+            const dx = pointer.x - node.x;
+            const dy = pointer.y - node.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist < pointer.radius) {
+              const influence = 1 - dist / pointer.radius;
+              if (pointer.polarity > 0) {
+                node.pointerGlow = Math.min(1.4, node.pointerGlow + influence * (0.4 + Math.random() * 0.2));
+              } else {
+                node.pointerShade = Math.min(1.2, node.pointerShade + influence * (0.35 + Math.random() * 0.25));
+              }
+            }
+          }
+        }
+
+        for (let i = 0; i < state.nodes.length; i++) {
+          const a = state.nodes[i];
+          const ax = a.x * width;
+          const ay = a.y * height;
+
+          const nearest = [
+            { dist: Infinity, index: -1 },
+            { dist: Infinity, index: -1 },
+            { dist: Infinity, index: -1 }
+          ];
+
+          for (let j = 0; j < state.nodes.length; j++) {
+            if (i === j) continue;
+            const b = state.nodes[j];
+            const dx = ax - b.x * width;
+            const dy = ay - b.y * height;
+            const dist = dx * dx + dy * dy;
+            if (dist < nearest[0].dist) {
+              nearest[2] = nearest[1];
+              nearest[1] = nearest[0];
+              nearest[0] = { dist, index: j };
+            } else if (dist < nearest[1].dist) {
+              nearest[2] = nearest[1];
+              nearest[1] = { dist, index: j };
+            } else if (dist < nearest[2].dist) {
+              nearest[2] = { dist, index: j };
+            }
+          }
+
+          const neighborIndices = new Set();
+          nearest.forEach(n => { if (n.index !== -1) neighborIndices.add(n.index); });
+          if (a.randomLink !== null) neighborIndices.add(a.randomLink);
+          if (a.randomLink2 !== null) neighborIndices.add(a.randomLink2);
+
+          const neighbors = Array.from(neighborIndices).map(idx => state.nodes[idx]);
+          const depthAlpha = (1 - a.z) * 0.45 + a.shimmer * 0.3;
+          const pointerLift = (a.pointerGlow - a.pointerShade) * 0.35;
+
+          for (const n of neighbors) {
+            const bx = n.x * width;
+            const by = n.y * height;
+            const partnerAlpha = (1 - n.z) * 0.4 + n.shimmer * 0.25;
+            const partnerPointer = (n.pointerGlow - n.pointerShade) * 0.35;
+            const edgeAlpha = Math.max(0.05, Math.min(0.75, (depthAlpha + partnerAlpha) * 0.5 + pointerLift + partnerPointer));
+            const gradient = ctx.createLinearGradient(ax, ay, bx, by);
+            gradient.addColorStop(0, `rgba(190, 220, 240, ${edgeAlpha})`);
+            gradient.addColorStop(0.6, `rgba(120, 160, 210, ${edgeAlpha * 0.75})`);
+            gradient.addColorStop(1, `rgba(40, 80, 140, ${Math.max(0.05, edgeAlpha * 0.6)})`);
+            ctx.strokeStyle = gradient;
+            ctx.lineWidth = 0.35 + (1 - a.z) * 1.25 + a.pointerGlow * 0.35;
+            ctx.globalAlpha = Math.min(1, 0.6 + state.visibility * 0.8);
+            ctx.beginPath();
+            ctx.moveTo(ax, ay);
+            ctx.lineTo(bx, by);
+            ctx.stroke();
+          }
+        }
+
+        ctx.globalAlpha = 1;
+
+        for (const node of state.nodes) {
+          const size = 10 + (1 - node.z) * 26;
+          const visibilityBoost = Math.min(1, state.visibility + 0.1);
+          const glow = node.pointerGlow;
+          const shade = node.pointerShade;
+          const alpha = Math.max(0.04, Math.min(0.5, (0.05 + (1 - node.z) * 0.22 + node.shimmer * 0.35 + glow * 0.4 - shade * 0.4) * visibilityBoost));
+          const x = node.x * width;
+          const y = node.y * height;
+          ctx.save();
+          ctx.translate(x, y);
+          ctx.globalAlpha = alpha;
+          ctx.fillStyle = 'rgba(210, 220, 230, 1)';
+          ctx.font = `${size}px "IBM Plex Mono", "SFMono-Regular", monospace`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.shadowColor = `rgba(190, 210, 240, ${0.25 + glow * 0.4})`;
+          ctx.shadowBlur = 18 + (1 - node.z) * 42 + glow * 30;
+          ctx.fillText(node.word, 0, 0);
+          ctx.restore();
+        }
+
+        ctx.restore();
+
+        state.mouse.speed *= 0.92;
+        noiseSeed += 0.00022 * (0.6 + state.visibility * 0.8);
+
+        requestAnimationFrame(update);
+      }
+      requestAnimationFrame(update);
+
+      let lastMouseTime = performance.now();
+      let lastMouseX = null;
+      let lastMouseY = null;
+      function pointerMove(e) {
+        const now = performance.now();
+        const { clientX: x, clientY: y } = e;
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        state.pointer.x = x / width;
+        state.pointer.y = y / height;
+        state.pointer.active = true;
+        state.pointer.lastMove = now;
+        state.pointer.polarity = Math.random() > 0.5 ? 1 : -1;
+        state.pointer.radius = rand(0.12, 0.2);
+
+        if (lastMouseX != null) {
+          const dx = x - lastMouseX;
+          const dy = y - lastMouseY;
+          const dt = now - lastMouseTime || 16;
+          const distance = Math.hypot(dx, dy);
+          const speed = distance / dt * 1000;
+          state.mouse.speed = Math.min(maxSpeed, state.mouse.speed * 0.6 + speed * 0.4 + Math.random() * 30);
+        }
+        lastMouseX = x;
+        lastMouseY = y;
+        lastMouseTime = now;
+      }
+
+      window.addEventListener('pointermove', pointerMove, { passive: true });
+      window.addEventListener('pointerleave', () => {
+        lastMouseX = null;
+        lastMouseY = null;
+        state.pointer.active = false;
+      });
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          state.mouse.speed = 0;
+          state.pointer.active = false;
+        }
+      });
+    })();
+  </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- lengthen the intro hold so ONONO lingers before the page reveal and slow the subsequent content fade-in
- delay the network canvas activation, cycle its visibility in dark pulses, and vary motion speeds for a less uniform feel
- intensify network edges and add dynamic connections with pointer-driven light/dim reactions for words and links

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_b_68e008b6a5008320a07fd5df429db1d8