### PR TITLE
Simplify hero transitions and add scroll hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,9 @@
     /* ====== Hero ====== */
     .hero{
       position:relative; isolation:isolate;
+      min-height:100vh;
+      display:flex;
+      align-items:center;
       padding-block: clamp(96px, 20vh, 160px);
       overflow:hidden;
       transition: transform 1.1s ease .45s, opacity 1.1s ease .45s;
@@ -92,66 +95,43 @@
       letter-spacing:-0.01em;
       margin:0;
     }
+    .hero h1 br{ display:block; }
     .hero-word{
-      position:relative;
-      display:inline-flex;
-      align-items:center;
-      white-space:nowrap;
-      min-width:6ch;
+      display:inline-block;
+      color:#9db2bf;
+      letter-spacing:0.12em;
+      font-weight:600;
+      min-width:8ch;
     }
     .hero-word .word-static{
-      position:relative;
-      z-index:1;
       display:inline-block;
-      transition: opacity .4s ease;
+      transition:opacity .36s ease;
     }
-    .hero-word .word-static.word-static--transitioning{
+    .hero-word .word-static.is-fading-out{
       opacity:0;
     }
-    .hero-word .word-static.word-static--revealed{
-      transition: opacity .6s ease;
-    }
-    .hero-word .word-fragments,
-    .hero-word .word-incoming{
-      position:absolute;
-      inset:0;
-      display:inline-flex;
-      align-items:center;
-      justify-content:center;
-      gap:0;
-      pointer-events:none;
-      mix-blend-mode:screen;
-    }
-    .hero-word .fragment{
-      display:inline-block;
-      white-space:pre;
-      transform-origin:center;
-    }
-    .hero-word .word-fragments .fragment{
-      animation: hero-word-tear .92s cubic-bezier(.4,.02,.14,1);
-      animation-delay: var(--delay, 0s);
-      filter: drop-shadow(0 12px 24px rgba(12,15,19,.6));
-    }
-    .hero-word .word-incoming .fragment{
-      animation: hero-word-assemble 1s cubic-bezier(.24,.82,.16,1);
-      animation-delay: calc(.16s + var(--delay, 0s));
-      filter: drop-shadow(0 6px 18px rgba(157,178,191,.25));
-    }
-    @keyframes hero-word-tear{
-      0%{ opacity:1; transform: translate3d(0,0,0) rotate(0deg) scale(1); filter: blur(0); }
-      40%{ opacity:.86; transform: translate3d(calc(var(--tx, 0)*18px), calc(var(--ty, 0)*22px),0) rotate(calc(var(--rot, 0)*40deg)) scale(1.08); filter: blur(1px); }
-      100%{ opacity:0; transform: translate3d(calc(var(--tx, 0)*58px), calc(var(--ty, 0)*64px),0) rotate(calc(var(--rot, 0)*120deg)) scale(.62); filter: blur(8px); }
-    }
-    @keyframes hero-word-assemble{
-      0%{ opacity:0; transform: translate3d(calc(var(--tx, 0)*-52px), calc(var(--ty, 0)*-48px),0) rotate(calc(var(--rot, 0)*-90deg)) scale(.4); filter: blur(10px); }
-      55%{ opacity:.9; transform: translate3d(calc(var(--tx, 0)*6px), calc(var(--ty, 0)*8px),0) rotate(calc(var(--rot, 0)*8deg)) scale(1.05); filter: blur(1px); }
-      100%{ opacity:1; transform: translate3d(0,0,0) rotate(0deg) scale(1); filter: blur(0); }
+    .hero-word .word-static.is-fading-in{
+      opacity:1;
     }
     .hero p{
       max-width: var(--maxw);
       font-size: clamp(1rem, 1.6vw, 1.125rem);
       color: var(--muted);
     }
+    .hero-motto{
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+      margin-top: clamp(10px, 2vw, 18px);
+      font-size:clamp(1rem, 1.4vw, 1.125rem);
+      color:var(--muted);
+    }
+    .hero-motto-line{
+      display:inline-block;
+      transition:opacity .36s ease;
+    }
+    .hero-motto-line.is-fading-out{ opacity:0; }
+    .hero-motto-line.is-fading-in{ opacity:1; }
     .cta{
       display:flex; gap:10px; flex-wrap:wrap; margin-top:10px;
     }
@@ -258,6 +238,39 @@
     }
     .skip:focus{ position:fixed; left:16px; top:12px; width:auto; height:auto; padding:8px 12px; background:#000; border:1px solid var(--edge); border-radius:10px; z-index:999; }
 
+    .scroll-hint{
+      position:fixed;
+      right:clamp(14px, 4vw, 32px);
+      bottom:clamp(14px, 4vw, 32px);
+      display:flex;
+      align-items:center;
+      gap:8px;
+      padding:8px 12px;
+      border:1px solid var(--edge);
+      border-radius:999px;
+      background: color-mix(in oklab, var(--bg) 80%, transparent);
+      color:var(--muted);
+      font-size:.75rem;
+      letter-spacing:.12em;
+      text-transform:uppercase;
+      opacity:.7;
+      transition: opacity .3s ease, transform .3s ease;
+      pointer-events:none;
+    }
+    .scroll-hint[data-hidden="true"]{
+      opacity:0;
+      transform: translateY(10px);
+    }
+    .scroll-hint-icon{
+      font-size:1rem;
+      line-height:1;
+      animation: scroll-hint-bob 2.4s ease-in-out infinite;
+    }
+    @keyframes scroll-hint-bob{
+      0%,100%{ transform: translateY(0); opacity:.6; }
+      50%{ transform: translateY(4px); opacity:1; }
+    }
+
     /* ====== Dimensional background canvas ====== */
     #networkCanvas{
       position:fixed;
@@ -348,15 +361,14 @@
     <section id="home" class="hero">
       <div class="container center">
         <span class="kicker">Stealth mode · Innovation-First</span>
-        <h1>From <span class="hero-word" data-hero-word aria-live="polite">Understanding</span> to Intelligence.</h1>
+        <h1>From <span class="hero-word" data-hero-word aria-live="polite">UNDERSTAND</span><br />to Intelligence.</h1>
         <p class="lead">
           We believe the mainstream AI path is misaligned with reality. The world is complex and shifting;
           more data or longer memory alone do not yield truth, understanding, or better decisions.
         </p>
-        <div class="cta">
-          <a class="btn btn-accent" href="#thesis">Read Thesis</a>
-          <a class="btn btn-ghost" href="#company">Company</a>
-          <a class="btn btn-ghost" href="#allies">Connect</a>
+        <div class="hero-motto">
+          <span class="hero-motto-line" data-hero-motto>Don’t accept the usual.</span>
+          <span>Resist.</span>
         </div>
         <div class="sigil" aria-hidden="true">
           <span class="sigil-ring"></span>
@@ -470,113 +482,187 @@
     </div>
   </footer>
 
+  <div class="scroll-hint" data-scroll-hint aria-hidden="true">
+    <span class="scroll-hint-text">Scroll</span>
+    <span class="scroll-hint-icon">⌄</span>
+  </div>
+
   <script>
     (function(){
+      const randRange = (min, max) => Math.random() * (max - min) + min;
+      const BASE_MIN = 3000;
+      const BASE_MAX = 5000;
+      const EXTRA_HOLD = 2000;
+      const FIRST_MULTIPLIER = 2.5;
+      const FIRST_RANGE = [BASE_MIN * FIRST_MULTIPLIER, BASE_MAX * FIRST_MULTIPLIER];
+      const REGULAR_RANGE = [BASE_MIN + EXTRA_HOLD, BASE_MAX + EXTRA_HOLD];
+
       const heroWordContainer = document.querySelector('[data-hero-word]');
       if (heroWordContainer) {
-        const heroWordOptions = [
+        const rawHeroOptions = [
           'Meaning', 'Interpretation', 'Explanation', 'Knowledge', 'Awareness', 'Consciousness', 'Perception', 'Insight',
           'Reflection', 'Reason', 'Thought', 'Comprehension', 'Cognition', 'Experience', 'Perspective', 'Narrative', 'Context',
           'Sense-making', 'Abstraction', 'Concept', 'Wisdom'
         ];
-        const baseWord = heroWordContainer.textContent.trim() || 'Understanding';
-        let currentWord = baseWord;
+        const baseWord = (heroWordContainer.textContent || 'UNDERSTAND').trim().toUpperCase();
+        const heroWordOptions = Array.from(new Set(rawHeroOptions.map(word => word.trim().toUpperCase()).filter(Boolean)));
+        if (!heroWordOptions.includes(baseWord)) {
+          heroWordOptions.push(baseWord);
+        }
+
         heroWordContainer.setAttribute('aria-atomic', 'true');
         const staticEl = document.createElement('span');
         staticEl.className = 'word-static';
-        staticEl.textContent = currentWord;
-        staticEl.dataset.word = currentWord;
+        staticEl.textContent = baseWord;
         heroWordContainer.textContent = '';
         heroWordContainer.appendChild(staticEl);
 
-        const heroRand = (min, max) => Math.random() * (max - min) + min;
-        const createFragmentContainer = (word, className) => {
-          const wrapper = document.createElement('span');
-          wrapper.className = className;
-          wrapper.setAttribute('aria-hidden', 'true');
-          const letters = word.length ? Array.from(word) : [''];
-          letters.forEach((letter, index) => {
-            const span = document.createElement('span');
-            span.className = 'fragment';
-            span.textContent = letter === ' ' ? ' ' : letter;
-            const angle = Math.random() * Math.PI * 2;
-            span.style.setProperty('--tx', Math.cos(angle).toFixed(3));
-            span.style.setProperty('--ty', Math.sin(angle).toFixed(3));
-            span.style.setProperty('--rot', (Math.random() * 2 - 1).toFixed(3));
-            span.style.setProperty('--delay', `${(index * 0.012 + Math.random() * 0.12).toFixed(3)}s`);
-            wrapper.appendChild(span);
-          });
-          return wrapper;
+        let currentWord = baseWord;
+        let heroTimer = null;
+        let heroWaitingForVisibility = false;
+        let heroUseFirstRange = true;
+
+        const scheduleHeroWord = () => {
+          clearTimeout(heroTimer);
+          const [min, max] = heroUseFirstRange ? FIRST_RANGE : REGULAR_RANGE;
+          heroUseFirstRange = false;
+          heroTimer = window.setTimeout(() => {
+            heroTimer = null;
+            if (document.hidden) {
+              heroWaitingForVisibility = true;
+              return;
+            }
+            changeHeroWord();
+          }, randRange(min, max));
         };
 
-        let changeTimer = null;
-        const queueNext = () => {
-          clearTimeout(changeTimer);
-          changeTimer = window.setTimeout(() => {
-            changeTimer = null;
-            runChange();
-          }, heroRand(3000, 5000));
-        };
-
-        const runChange = () => {
-          if (document.hidden) {
-            changeTimer = null;
-            return;
-          }
+        const changeHeroWord = () => {
           const candidates = heroWordOptions.filter(word => word !== currentWord);
           if (!candidates.length) {
-            queueNext();
+            scheduleHeroWord();
             return;
           }
           const nextWord = candidates[Math.floor(Math.random() * candidates.length)];
-          if (!nextWord || nextWord === currentWord) {
-            queueNext();
-            return;
-          }
-
-          const outgoing = createFragmentContainer(currentWord, 'word-fragments');
-          const incoming = createFragmentContainer(nextWord, 'word-incoming');
-          heroWordContainer.appendChild(outgoing);
-          heroWordContainer.appendChild(incoming);
-
-          staticEl.classList.add('word-static--transitioning');
+          staticEl.classList.add('is-fading-out');
           window.setTimeout(() => {
             staticEl.textContent = nextWord;
-            staticEl.dataset.word = nextWord;
-            staticEl.classList.add('word-static--revealed');
-            staticEl.classList.remove('word-static--transitioning');
+            staticEl.classList.remove('is-fading-out');
+            staticEl.classList.add('is-fading-in');
             window.setTimeout(() => {
-              staticEl.classList.remove('word-static--revealed');
+              staticEl.classList.remove('is-fading-in');
             }, 360);
-          }, 420);
-
-          window.setTimeout(() => {
-            outgoing.remove();
-            incoming.remove();
-          }, 1200);
-
+          }, 200);
           currentWord = nextWord;
-          queueNext();
+          scheduleHeroWord();
         };
 
-        window.setTimeout(() => {
-          if (!document.hidden) {
-            runChange();
-          } else {
-            changeTimer = null;
-          }
-        }, 3000);
+        scheduleHeroWord();
 
         document.addEventListener('visibilitychange', () => {
           if (document.hidden) {
-            clearTimeout(changeTimer);
-            changeTimer = null;
-          } else if (changeTimer === null) {
-            queueNext();
+            clearTimeout(heroTimer);
+            heroTimer = null;
+            heroWaitingForVisibility = true;
+          } else if (heroWaitingForVisibility || heroTimer === null) {
+            heroWaitingForVisibility = false;
+            scheduleHeroWord();
           }
         });
       }
 
+      const heroMottoLine = document.querySelector('[data-hero-motto]');
+      if (heroMottoLine) {
+        const mottoOptions = [
+          "Don’t accept the usual.",
+          "Don’t follow the crowd.",
+          "Don’t chase the mainstream.",
+          "Don’t be ruled by habit.",
+          "Don’t be led by noise.",
+          "Don’t follow hype.",
+          "Don’t let the loudest lead.",
+          "Don’t fetishize benchmarks."
+        ].map(text => text.trim()).filter(Boolean);
+        const basePhrase = (heroMottoLine.textContent || mottoOptions[0]).trim();
+        if (!mottoOptions.includes(basePhrase)) {
+          mottoOptions.push(basePhrase);
+        }
+
+        heroMottoLine.setAttribute('aria-live', 'polite');
+        heroMottoLine.setAttribute('aria-atomic', 'true');
+
+        let currentPhrase = basePhrase;
+        let mottoTimer = null;
+        let mottoWaitingForVisibility = false;
+        let mottoUseFirstRange = true;
+
+        const scheduleMotto = () => {
+          clearTimeout(mottoTimer);
+          const [min, max] = mottoUseFirstRange ? FIRST_RANGE : REGULAR_RANGE;
+          mottoUseFirstRange = false;
+          mottoTimer = window.setTimeout(() => {
+            mottoTimer = null;
+            if (document.hidden) {
+              mottoWaitingForVisibility = true;
+              return;
+            }
+            changeMottoPhrase();
+          }, randRange(min, max));
+        };
+
+        const changeMottoPhrase = () => {
+          const candidates = mottoOptions.filter(phrase => phrase !== currentPhrase);
+          if (!candidates.length) {
+            scheduleMotto();
+            return;
+          }
+          const nextPhrase = candidates[Math.floor(Math.random() * candidates.length)];
+          heroMottoLine.classList.add('is-fading-out');
+          window.setTimeout(() => {
+            heroMottoLine.textContent = nextPhrase;
+            heroMottoLine.classList.remove('is-fading-out');
+            heroMottoLine.classList.add('is-fading-in');
+            window.setTimeout(() => {
+              heroMottoLine.classList.remove('is-fading-in');
+            }, 360);
+          }, 200);
+          currentPhrase = nextPhrase;
+          scheduleMotto();
+        };
+
+        scheduleMotto();
+
+        document.addEventListener('visibilitychange', () => {
+          if (document.hidden) {
+            clearTimeout(mottoTimer);
+            mottoTimer = null;
+            mottoWaitingForVisibility = true;
+          } else if (mottoWaitingForVisibility || mottoTimer === null) {
+            mottoWaitingForVisibility = false;
+            scheduleMotto();
+          }
+        });
+      }
+
+      const scrollHint = document.querySelector('[data-scroll-hint]');
+      if (scrollHint) {
+        const updateScrollHint = () => {
+          const scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
+          const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+          const scrollHeight = document.documentElement.scrollHeight || document.body.scrollHeight || 0;
+          const atBottom = scrollTop + viewportHeight >= scrollHeight - 4;
+          const isScrollable = scrollHeight > viewportHeight + 4;
+          scrollHint.dataset.hidden = (!isScrollable || atBottom) ? 'true' : 'false';
+        };
+
+        updateScrollHint();
+        document.addEventListener('scroll', updateScrollHint, { passive: true });
+        window.addEventListener('resize', updateScrollHint);
+        document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) {
+            updateScrollHint();
+          }
+        });
+      }
       const body = document.body;
       const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
       if (motionQuery.matches) {


### PR DESCRIPTION
## Summary
- simplify the hero headline animation with uppercase UNDERSTAND styling, longer dwell times, and a matching motto rotator
- replace the hero CTA buttons with the new two-line motto and ensure the hero section fills the viewport
- add a subtle bottom-right scroll hint that hides when the page is fully scrolled

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_b_68e01faebe448320a0643624ea896f4e